### PR TITLE
Check some segfaults . spotted on strnstr + strncmp

### DIFF
--- a/ft_strncmp.c
+++ b/ft_strncmp.c
@@ -18,6 +18,8 @@ int	ft_strncmp(const char *s1, const char *s2, size_t n)
 	unsigned char	*str1;
 	unsigned char	*str2;
 
+	if (!s1 && !s2)
+		return (0);
 	str1 = ((unsigned char *) s1);
 	str2 = ((unsigned char *) s2);
 	i = 0;

--- a/ft_strnstr.c
+++ b/ft_strnstr.c
@@ -26,6 +26,8 @@ char	*ft_strnstr(const char *big, const char *little, size_t len)
 
 	i = 0;
 	j = 0;
+	if (!little)
+		return (NULL);
 	if (!little[0])
 		return ((char *) big);
 	while (big[i] && i < len)

--- a/ft_strnstr.c
+++ b/ft_strnstr.c
@@ -26,7 +26,7 @@ char	*ft_strnstr(const char *big, const char *little, size_t len)
 
 	i = 0;
 	j = 0;
-	if (!little)
+	if (!little || !big)
 		return (NULL);
 	if (!little[0])
 		return ((char *) big);


### PR DESCRIPTION
Segv when both s1 and s2 passed NULL to strncmp with a valid size, (std strncmp doesn't segv)

Segv if any of big or little is passed NULL , dereferencing directly which can cause a segv if it were null pointer.